### PR TITLE
Improve progress reporting after each task

### DIFF
--- a/mainpopperarc.py
+++ b/mainpopperarc.py
@@ -10,6 +10,7 @@ import concurrent.futures
 import psutil
 import logging
 
+logger = logging.getLogger(__name__)
 from init.init import prepare_arc_data, get_test_pairs
 from bkbias.objattr import (
     determine_background_color,
@@ -55,18 +56,38 @@ def solve_task(
     exs_use_pixels: bool | None,
     enable_pi: bool,
     bg_threshold: int,
+    popper_timeout: int,
+    max_clauses: int,
+    max_vars: int,
+    max_body: int,
     popper_debug: bool = True,
     show_stdout: bool = True,
 ) -> Tuple[bool, str | None]:
-    """Generate Popper files for a task and run the solver."""
+    """Generate Popper files for a task and run the solver.
+
+    Parameters
+    ----------
+    popper_timeout : int
+        Maximum time allowed for Popper in seconds.
+    max_clauses, max_vars, max_body : int
+        Bias parameters passed to :func:`generate_bias`.
+    """
     out_dir = os.path.join(output_base, task_id)
     try:
         bg_color = determine_background_color(
             task_data, pixel_threshold_pct=bg_threshold, debug=True
         )
         for idx, pair in enumerate(task_data.get("train", [])):
-            print_grid(pair.get("input"), f"Train {task_id} input {idx}")
-            print_grid(pair.get("output"), f"Train {task_id} output {idx}")
+            print_grid(
+                pair.get("input"),
+                f"Train {task_id} input {idx}",
+                background_color=bg_color,
+            )
+            print_grid(
+                pair.get("output"),
+                f"Train {task_id} output {idx}",
+                background_color=bg_color,
+            )
         bk_path, bias_path, exs_path = generate_files_from_task(
             task_data,
             out_dir,
@@ -76,12 +97,20 @@ def solve_task(
             enable_pi=enable_pi,
             pixel_threshold_pct=bg_threshold,
             background_color=bg_color,
+            max_clauses=max_clauses,
+            max_vars=max_vars,
+            max_body=max_body,
         )
         # for label, path in ("BK", bk_path), ("Bias", bias_path), ("Examples", exs_path):
         #     print(f"\n============================================== {label} for {task_id} =======================")
         #     with open(path) as f:
         #         print(f.read())
-        prog_path, info = run_popper_from_dir(out_dir, debug=popper_debug, show_output=show_stdout)
+        prog_path, info = run_popper_from_dir(
+            out_dir,
+            timeout=popper_timeout,
+            debug=popper_debug,
+            show_output=show_stdout,
+        )
         score = info.get("score")
         if prog_path is not None:
             print(f"！！！！！！！！！！！！！！！！！！！！！！Solved {task_id} with score {score}")
@@ -95,6 +124,79 @@ def solve_task(
         print(f"Error processing {task_id}: {e}")
         traceback.print_exc()
         return False, None
+
+
+def run_test_evaluation(
+    hyp_path: str,
+    task_id: str,
+    train_tasks: Dict[str, Any],
+    train_sols: Dict[str, Any],
+    *,
+    output_base: str,
+    enable_pi: bool,
+    bg_threshold: int,
+) -> List[Dict[str, Any]]:
+    """Run prediction tests for ``task_id`` and collect metrics."""
+
+    logger.debug("Running evaluation for %s", task_id)
+    results = []
+    pairs = get_test_pairs(task_id, train_tasks, train_sols)
+    for t_idx, pair in enumerate(pairs):
+        test_dir = os.path.join(output_base, task_id, f"test{t_idx}")
+        pair_data = {"train": [{"input": pair["input"], "output": pair["output"]}]}
+        bg_color = determine_background_color(
+            pair_data, pixel_threshold_pct=bg_threshold, debug=False
+        )
+        print_grid(pair["input"], f"Test {t_idx} input", background_color=bg_color)
+        print_grid(
+            pair["output"], f"Test {t_idx} expected", background_color=bg_color
+        )
+        bk_path = generate_test_bk(
+            pair["input"],
+            pair["output"],
+            test_dir,
+            enable_pi=enable_pi,
+            background_color=None,
+            pixel_threshold_pct=bg_threshold,
+        )
+        meta_path = os.path.join(test_dir, "grid_meta.json")
+        pred_grid = predict_from_prolog(hyp_path, bk_path, meta_path, pair_id="p0")
+        print_grid(
+            pred_grid,
+            f"Test {t_idx} predicted",
+            background_color=bg_color,
+        )
+        save_grid_txt(pred_grid, os.path.join(test_dir, "pred.txt"))
+        logger.debug("Evaluation %s test %s predicted grid saved", task_id, t_idx)
+        exact, pix_acc = evaluate_prediction(pred_grid, pair["output"])
+        print(f"Test {t_idx} - Exact match? {exact}")
+        print(f"Test {t_idx} - Pixel accuracy: {pix_acc}")
+        results.append({"index": t_idx, "exact": exact, "pixel_accuracy": pix_acc})
+        logger.debug(
+            "Evaluation %s test %s result: exact=%s, acc=%s",
+            task_id,
+            t_idx,
+            exact,
+            pix_acc,
+        )
+
+    return results
+
+
+def all_tests_successful(results: List[Dict[str, Any]]) -> bool:
+    """Return ``True`` if all test cases are exact matches with 100% accuracy."""
+
+    return all(r["exact"] and r["pixel_accuracy"] == 1.0 for r in results)
+
+
+def print_progress(success_count: int, completed: int, total: int) -> None:
+    """Display progress information for completed tasks."""
+
+    fail_count = completed - success_count
+    print(
+        f"Progress - 成功 {success_count}/{total} 失败 {fail_count}/{total}"
+    )
+
 
 
 def main() -> None:
@@ -156,9 +258,39 @@ def main() -> None:
         default=False,
         help="Run Popper in debug mode",
     )
+    parser.add_argument(
+        "--popper-timeout",
+        type=int,
+        default=200,
+        help="Maximum time allowed for Popper per task (seconds)",
+    )
+    parser.add_argument(
+        "--max-clauses",
+        type=int,
+        default=4,
+        help="Bias setting max_clauses",
+    )
+    parser.add_argument(
+        "--max-vars",
+        type=int,
+        default=6,
+        help="Bias setting max_vars",
+    )
+    parser.add_argument(
+        "--max-body",
+        type=int,
+        default=4,
+        help="Bias setting max_body",
+    )
+    parser.add_argument(
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable verbose logging",
+    )
     args = parser.parse_args()
 
-    if args.popper_debug:
+    if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
 
     use_pixels = args.repr == "pixels"
@@ -175,6 +307,8 @@ def main() -> None:
     os.makedirs(args.out, exist_ok=True)
 
     success_count = 0
+    all_results: Dict[str, List[Dict[str, Any]]] = {}
+    tasks_completed = 0
     if args.task_id:
         selected = [(tid, cnt) for tid, cnt in task_counts if tid == args.task_id]
     else:
@@ -195,6 +329,7 @@ def main() -> None:
                 " * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * "
             )
             print(f"Queueing {tid} ({idx}/{total_tasks})")
+            logger.debug("Queueing task %s", tid)
             fut = ex.submit(
                 solve_task,
                 tid,
@@ -205,6 +340,10 @@ def main() -> None:
                 exs_use_pixels=exs_use_pixels,
                 enable_pi=args.enable_pi,
                 bg_threshold=args.bg_threshold,
+                popper_timeout=args.popper_timeout,
+                max_clauses=args.max_clauses,
+                max_vars=args.max_vars,
+                max_body=args.max_body,
                 popper_debug=args.popper_debug,
                 show_stdout=(tid == show_stdout_tid),
             )
@@ -217,34 +356,39 @@ def main() -> None:
             except Exception as e:
                 print(f"Task {tid} failed: {e}")
                 traceback.print_exc()
+                tasks_completed += 1
+                print_progress(success_count, tasks_completed, total_tasks)
                 continue
 
             if solved and hyp:
-                success_count += 1
-                print(f"当前成功记录数: {success_count}")
-                test_pairs = get_test_pairs(tid, train_tasks, train_sols)
-                for t_idx, pair in enumerate(test_pairs):
-                    test_dir = os.path.join(args.out, tid, f"test{t_idx}")
-                    print_grid(pair["input"], f"Test {t_idx} input")
-                    print_grid(pair["output"], f"Test {t_idx} expected")
-                    bk_path = generate_test_bk(
-                        pair["input"],
-                        pair["output"],
-                        test_dir,
-                        enable_pi=args.enable_pi,
-                        background_color=None,
-                        pixel_threshold_pct=args.bg_threshold,
-                    )
-                    meta_path = os.path.join(test_dir, "grid_meta.json")
-                    pred_grid = predict_from_prolog(hyp, bk_path, meta_path, pair_id="p0")
-                    print_grid(pred_grid, f"Test {t_idx} predicted")
-                    save_grid_txt(pred_grid, os.path.join(test_dir, "pred.txt"))
-                    exact, pix_acc = evaluate_prediction(pred_grid, pair["output"])
-                    print(f"Test {t_idx} - Exact match? {exact}")
-                    print(f"Test {t_idx} - Pixel accuracy: {pix_acc}")
+                task_results = run_test_evaluation(
+                    hyp,
+                    tid,
+                    train_tasks,
+                    train_sols,
+                    output_base=args.out,
+                    enable_pi=args.enable_pi,
+                    bg_threshold=args.bg_threshold,
+                )
+
+                all_results[tid] = task_results
+                print(f"Task {tid} results: {task_results}")
+                if all_tests_successful(task_results):
+                    success_count += 1
+
+            tasks_completed += 1
+            print_progress(success_count, tasks_completed, total_tasks)
 
             print('\n')
             print(f"Finished {tid}\n")
+            logger.debug("Completed task %s", tid)
+
+    print("\n=== Summary ===")
+    print(f"Total solved: {success_count}/{total_tasks}")
+    for tid, results in all_results.items():
+        print(f"Results for {tid}:")
+        for res in results:
+            print(f"  Test {res['index']} - exact={res['exact']} acc={res['pixel_accuracy']}")
 
 
 


### PR DESCRIPTION
## Summary
- add `print_progress` helper to report successes and failures
- track tasks completed and show progress as tasks finish
- support configurable Popper timeout and bias settings via CLI
- swap background and black colors when rendering grids

## Testing
- `python -m py_compile mainpopperarc.py bkbias/objattr.py`
- `pip install git+https://github.com/logic-and-learning-lab/Popper@main` *(fails: RuntimeError: Failed to find SWI-Prolog components)*

------
https://chatgpt.com/codex/tasks/task_e_6861fdf06f148323bd498002cd03ebe9