### PR TITLE
refactor object extraction with transformation analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ if prog is not None:
 
 This repository contains utilities in `bkbias/objattr.py` to generate the BK, bias and example files from an ARC task and run Popper programmatically.
 
+Recent refactoring separates object extraction from file generation.  Use
+`extract_objects_from_task` and `analyze_task_transformations` to inspect how
+input objects map to outputs before calling `generate_files_from_task`.
+
 ### Example: run Popper on a task
 
 ```

--- a/bkbias/object_matching.py
+++ b/bkbias/object_matching.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+from typing import List, Dict, Any, Tuple
+
+
+def _analyze_input_to_output_transformation(
+    pair_id: int,
+    input_grid: List[List[int]],
+    output_grid: List[List[int]],
+    input_obj_infos: List[Dict[str, Any]],
+    output_obj_infos: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Analyze how input objects transform into output objects.
+
+    This is a simplified port of the old `_analyze_input_to_output_transformation`
+    routine used in the previous project.  It works with the dictionary based
+    object infos produced by :func:`extract_objects_from_task`.
+
+    The function identifies preserved, modified, removed and added objects based
+    on shape equality (using ``obj_000``) and tracks simple position and color
+    changes.
+    """
+    transformation_rule: Dict[str, Any] = {
+        "pair_id": pair_id,
+        "preserved_objects": [],
+        "modified_objects": [],
+        "removed_objects": [],
+        "added_objects": [],
+    }
+
+    unmatched_out = output_obj_infos.copy()
+
+    for in_obj in input_obj_infos:
+        match = None
+        for out_obj in unmatched_out:
+            if in_obj["obj_000"] == out_obj["obj_000"]:
+                match = out_obj
+                break
+        if match is not None:
+            delta_row = match["top"] - in_obj["top"]
+            delta_col = match["left"] - in_obj["left"]
+            color_change = (
+                None
+                if in_obj.get("main_color") == match.get("main_color")
+                else {
+                    "from": in_obj.get("main_color"),
+                    "to": match.get("main_color"),
+                }
+            )
+            if delta_row == 0 and delta_col == 0 and color_change is None:
+                transformation_rule["preserved_objects"].append(
+                    {
+                        "input_obj_id": in_obj["obj_id"],
+                        "output_obj_id": match["obj_id"],
+                        "object": in_obj,
+                    }
+                )
+            else:
+                transformation_rule["modified_objects"].append(
+                    {
+                        "input_obj_id": in_obj["obj_id"],
+                        "output_obj_id": match["obj_id"],
+                        "position_change": {
+                            "delta_row": delta_row,
+                            "delta_col": delta_col,
+                        },
+                        "color_change": color_change,
+                    }
+                )
+            unmatched_out.remove(match)
+        else:
+            transformation_rule["removed_objects"].append(
+                {
+                    "input_obj_id": in_obj["obj_id"],
+                    "object": in_obj,
+                }
+            )
+
+    for out_obj in unmatched_out:
+        transformation_rule["added_objects"].append(
+            {
+                "output_obj_id": out_obj["obj_id"],
+                "object": out_obj,
+            }
+        )
+
+    return transformation_rule
+
+
+def analyze_task_transformations(
+    task_data: Dict[str, Any],
+    all_objects: Dict[str, List[Tuple[int, List[Dict[str, Any]]]]],
+) -> List[Tuple[int, Dict[str, Any]]]:
+    """Analyze transformations for all train pairs in a task."""
+    transformations: List[Tuple[int, Dict[str, Any]]] = []
+    for (pair_id, in_objs), (_, out_objs) in zip(
+        all_objects.get("input", []), all_objects.get("output", [])
+    ):
+        pair = task_data["train"][pair_id]
+        rule = _analyze_input_to_output_transformation(
+            pair_id,
+            pair["input"],
+            pair["output"],
+            in_objs,
+            out_objs,
+        )
+        transformations.append((pair_id, rule))
+    return transformations
+

--- a/mainpopperarc.py
+++ b/mainpopperarc.py
@@ -18,6 +18,8 @@ from init.init import prepare_arc_data, get_test_pairs
 from bkbias.objattr import (
     determine_background_color,
     generate_files_from_task,
+    extract_objects_from_task,
+    
     nonbg_pixels,
     run_popper_from_dir,
     generate_test_bk,
@@ -97,6 +99,10 @@ def solve_task(
             for idx, pair in enumerate(task_data.get("train", [])):
                 print_grid(pair.get("input"), f"Train {task_id} input {idx}")
                 print_grid(pair.get("output"), f"Train {task_id} output {idx}")
+        objs = extract_objects_from_task(task_data, bg_color)
+        from bkbias.object_matching import analyze_task_transformations
+
+        transformations = analyze_task_transformations(task_data, objs)
         bk_path, bias_path, exs_path = generate_files_from_task(
             task_data,
             out_dir,
@@ -109,6 +115,8 @@ def solve_task(
             max_clauses=max_clauses,
             max_vars=max_vars,
             max_body=max_body,
+            objs=objs,
+            transformations=transformations,
         )
         # for label, path in ("BK", bk_path), ("Bias", bias_path), ("Examples", exs_path):
         #     print(f"\n============================================== {label} for {task_id} =======================")


### PR DESCRIPTION
## Summary
- allow passing pre-extracted objects and transformation data into `generate_files_from_task`
- add lightweight `_analyze_input_to_output_transformation` and `analyze_task_transformations`
- run Popper workflows after explicit object extraction and transformation analysis
- document the extraction and transformation workflow in README

## Testing
- `python - <<'PY'
from bkbias.objattr import extract_objects_from_task, generate_files_from_task
from bkbias.object_matching import analyze_task_transformations
import os

simple_task = {
    "train": [
        {"input": [[1,0],[0,0]], "output": [[1,0],[1,0]]}
    ]
}

objs = extract_objects_from_task(simple_task)
trans = analyze_task_transformations(simple_task, objs)

out_dir = 'test_output'
os.makedirs(out_dir, exist_ok=True)

generate_files_from_task(simple_task, out_dir, objs=objs, transformations=trans)
print('Generated files:', sorted(os.listdir(out_dir)))
PY`


------
https://chatgpt.com/codex/tasks/task_b_68aad9922f608321a9335f0f2d56479e